### PR TITLE
workflow: add basic sanity build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: build CI
+
+on:
+  push:
+      branches: [ master ]
+  pull_request:
+      branches: [ master ]
+
+jobs:
+  build:
+      runs-on: ubuntu-22.04
+      steps:
+      - uses: actions/checkout@v2
+      - name: configure
+        run: ./configure
+      - name: make
+        run: make


### PR DESCRIPTION
Problem: There's no basic build test for whatsup.

Add a basic build workflow.